### PR TITLE
Removing Samba deployment in container

### DIFF
--- a/.startup
+++ b/.startup
@@ -1,7 +1,7 @@
 
-/usr/sbin/ntpd -p /var/run/ntp/ntpd.pid -g -u ntp:ntp -c /etc/ntp.conf
-/usr/sbin/smbd -D
-/usr/sbin/nmbd -D
+# /usr/sbin/ntpd -p /var/run/ntp/ntpd.pid -g -u ntp:ntp -c /etc/ntp.conf
+# /usr/sbin/smbd -D
+# /usr/sbin/nmbd -D
 
 export PATH=$PATH:/sbin:/usr/sbin:/home/rtadmin/RTafni/bin:/home/rtadmin/RTafni/bin/AFNI:.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive install \
                                      wget cmake gcc gcc-c++ xeyes
 
 ADD ntp.conf                  /etc
-ADD smb.conf                  /etc/samba
+# ADD smb.conf                  /etc/samba
 
 ADD meduser.bashrc            /home/meduser/.bashrc
 ADD .afnirc                   /home/rtadmin
@@ -54,7 +54,7 @@ RUN chown -R rtadmin:users    /home/rtadmin
 ADD .startup                  /root
 
 # Allow Siemens console access to the Samba shares and start it monitoring for RT
-RUN smbpasswd -L -n -a meduser
+# RUN smbpasswd -L -n -a meduser
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ enable running Samba from within the container, in the Dockerfile, the
 comment ('#') marks should be removed from the following lines:
 
    # ADD smb.conf                  /etc/samba
+
    # RUN smbpasswd -L -n -a meduser
 
 The lines starting up Samba in the '.startup' script (that is copied to

--- a/README.md
+++ b/README.md
@@ -4,8 +4,27 @@
 This reposiotry will hold a Docker container build configuration, in
 addition to program files to support FMRIF's real-time AFNI framework.
 
-The first time the container is run, the Samba password for the meduser
-account must be set, with the command:
+Initial iterations of building this container had it running Samba to
+provide a shared volume to the MRI scanner console.  This capability
+has been disabled in the current iteration of the container build due
+to the persistence issue of Samba being only available when the container
+is running, and any remote volume connection issues that might arise if
+the service provision depends on the container running or not.
+
+If running Samba within the container is desired, all the necessary
+software and configurations are still included in this repository. To
+enable running Samba from within the container, in the Dockerfile, the
+comment ('#') marks should be removed from the following lines:
+
+   # ADD smb.conf                  /etc/samba
+   # RUN smbpasswd -L -n -a meduser
+
+The lines starting up Samba in the '.startup' script (that is copied to
+the container, and is the command that the container starts up with)
+should also have their '#' comment marks removed.
+
+Then, the first time the container is run, the Samba password for the
+meduser account must be set, with the command:
 
    ```bash
    smbpasswd meduser
@@ -14,28 +33,8 @@ account must be set, with the command:
 and after this, the volume shared by the container (/data0) should be
 accessible from the MRI's console computer via Windows File Sharing.
 
-The container's super-user should also switch to the container's
-'rtadmin' user, and run:
-
-   ```bash
-   cd ~rtadmin/RTafni/src
-   ./getBuildInstallGDCM.sh
-   ```
-
-as that user.  This will retrieve and install the GrassRoots DICOM
-package, which is used to parse and retrieve information which
-cannot be obtained by the pydicom libraries (for example, information
-in the vendor's private DICOM fields).
-
-The container's 'rtadmin' user should also run:
-
-   ```bash
-   @update.afni.binaries -package linux_openmp_64 -bindir /home/rtadmin/RTafni/bin/AFNI/
-   ```
-
-to retrieve and install the latest AFNI binaries.
-
-The command to run this container is:
+The command to run this container with Samba services and accompanyting
+ports available is:
 
    ```bash
    docker run --name rtAFNI -p 138:138/udp -p 139:139 -p 445:445 -p 445:445/udp -p 8111:8111 \
@@ -43,13 +42,30 @@ The command to run this container is:
                             -it dockerAcctName/containerName:version
    ```
 
+Without Samba services (current container configuration), the command
+to run this is:
+
+   ```bash
+   docker run --name rtAFNI -p 8111:8111 \
+                            -e DISPLAY=unix$DISPLAY -v /data0/:/data0 -v /tmp/.X11-unix/:/tmp/.X11-unix/ \
+                            -it dockerAcctName/containerName:version
+   ```
+
+This will start the container with all of the port chosen for the scanner
+console to send messages to, and for the DICOM listener (running in the
+container) to observe.
+
 The tip about which variables to pass through to get X11 apps forwarded
 through and displaying on host was found at:
 
    https://blog.jessfraz.com/post/docker-containers-on-the-desktop/
 
-This will start the container with all of the ports needed for Samba
-opened and mapped, and the port chosen for the scanner console to send
-messages to, and for the DICOM listener (running in the container) to
-observe.
+This has pointed the container to the correct X11 DISPLAY to use, but a:
+
+   ```bash
+   xhost +
+   ```
+
+commnad on the host PC might still be needed to allow X11 connections
+from the container to be established.
 


### PR DESCRIPTION
The bulk of the functional changes remove the starting of Samba from within the container.  That function should stay on the host PC for persistence considerations.

Documentation / Readme has also be updated to reflect not using Samba within container.